### PR TITLE
Implement PageVisibility API

### DIFF
--- a/src/Native/PageVisibility.js
+++ b/src/Native/PageVisibility.js
@@ -1,0 +1,44 @@
+// setup
+Elm.Native = Elm.Native || {};
+Elm.Native.PageVisibility = Elm.Native.PageVisibility || {};
+
+// definition
+Elm.Native.PageVisibility.make = function(localRuntime) {
+  'use strict';
+
+  // attempt to short-circuit
+  localRuntime.Native = localRuntime.Native || {};
+  localRuntime.Native.PageVisibility = localRuntime.Native.PageVisibility || {};
+  if ('values' in localRuntime.Native.PageVisibility)
+  {
+    return localRuntime.Native.PageVisibility.values;
+  }
+
+  var prefix = '';
+
+  if (typeof document.hidden === "undefined") {
+    if (typeof document.mozHidden !== "undefined") {
+      prefix = 'moz';
+    }
+    else if (typeof document.msHidden !== "undefined") {
+      prefix = 'ms';
+    }
+    else if (typeof document.webkitHidden !== "undefined") {
+      prefix = 'webkit';
+    }
+  }
+
+  var NS = Elm.Native.Signal.make(localRuntime);
+
+  var state = NS.input('visibilitychange', { ctor: 'Visible' });
+
+  localRuntime.addListener([state.id], document, prefix + 'visibilitychange', function() {
+    localRuntime.notify(state.id, {
+      ctor: (document[prefix + 'hidden']) ? 'Hidden' : 'Visible'
+    });
+  });
+
+  return localRuntime.Native.PageVisibility.values = {
+    state: state
+  };
+};

--- a/src/PageVisibility.elm
+++ b/src/PageVisibility.elm
@@ -1,0 +1,48 @@
+module PageVisibility where
+
+{-| Bindings for the [PageVisiblity API][page-visibility]
+
+[page-visibility]: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+
+# Visibility state
+@docs State, state
+
+# State flags
+@docs hidden, visible
+
+-}
+
+import Native.PageVisibility
+
+
+{-| Page visibility can have two states, either visible or hidden.
+
+The state will be `Hidden` whenever the current tab is not the active tab or
+browser window is in the background.
+
+The state will be 'Visible' when the page is the main browser window and it is
+visible (not minimized).
+-}
+type State
+    = Hidden
+    | Visible
+
+
+{-| Current page visibility state
+-}
+state : Signal State
+state =
+  Native.PageVisibility.state
+
+
+{-| Page is hidden
+-}
+hidden : Signal Bool
+hidden =
+  Signal.map ((==) Hidden) state
+
+{-| Page is visible
+-}
+visible : Signal Bool
+visible =
+  Signal.map ((==) Visible) state


### PR DESCRIPTION
I need this for a project I'm working on, so I implemented it. The code is pretty straightforward.

Quick example:

``` elm
module Main where

import Graphics.Element exposing (show)
import PageVisibility as PV

main : Signal Graphics.Element.Element
main =
  Signal.map show <| Signal.foldp (::) [] PV.state
```

I'm not to crazy about keeping this as I've implemented it, because it's done somewhat specifically to my needs, so feel free to make whatever changes you like :)
